### PR TITLE
uses asyncapi-cli instead of asyncapi-generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,11 @@ Create a new markdown file which contains only this line:
 `path-to-spec-file` is the path to the AsyncAPI spec file relative to the root of the repository (where you run `mkdocs`).
 
 Then, the entire content of this file will be the AsyncAPI spec.
+
+## Configuration
+You can configure the output with the supported [supported parameters](https://github.com/asyncapi/markdown-template?tab=readme-ov-file#supported-parameters) of the template.
+
+For example:
+```markdown
+!!asyncapi <path-to-spec-file> toc=false!!
+```

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 
 ## Setup
 
-1. Install [`asyncapi/generator`](https://github.com/asyncapi/generator)
+1. Install [`asyncapi/cli`](https://github.com/asyncapi/cli)
 
 ``` sh
-npm install -g @asyncapi/generator
+npm install -g @asyncapi/cli
 ```
 
 2. Install this plugin.

--- a/mkdocs_asyncapi_plugin.py
+++ b/mkdocs_asyncapi_plugin.py
@@ -20,21 +20,24 @@ class AsyncAPIPlugin(mkdocs.plugins.BasePlugin):
         path = match.group("path")
 
         indir = "docs"
+        fname = os.path.basename(path)
+        fname = os.path.splitext(fname)[0]
         with tempfile.TemporaryDirectory() as outdir:
             infile = os.path.join(indir, path)
             subprocess.run(
                 [
-                    "ag",
+                    "asyncapi",
+                    "generate",
+                    "fromTemplate",
                     infile,
-                    "@asyncapi/markdown-template",
+                    "@asyncapi/markdown-template@1.2.1",
                     "--force-write",
                     "-o",
                     outdir,
+                    "-p", f"outFilename={fname}.md"
                 ],
                 check=True,
             )
-            fname = os.path.basename(path)
-            fname = os.path.splitext(fname)[0]
             outfile = os.path.join(outdir, fname + ".md")
             with open(outfile) as f:
                 generated = f.read()


### PR DESCRIPTION
[Asyncapi generator cli `ag` is deprecated](https://github.com/asyncapi/generator/releases/tag/%40asyncapi%2Fgenerator%402.6.0). 
So this PR changes the plugin to use the `asyncapi-cli` instead. 

Also enables support for the template parameters.